### PR TITLE
docs(ops): add wiki docs, ADR structure, and discussions workflow drafts

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -1,0 +1,34 @@
+name: Auto Response (Draft)
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  auto-response:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Respond to new issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue_number = context.payload.issue.number;
+            const body = [
+              "감사합니다. 이슈를 접수했습니다.",
+              "",
+              "- 24시간 내 1차 확인",
+              "- 우선순위 라벨링 후 백로그 반영",
+              "",
+              "추가 로그/재현 절차를 댓글로 남겨주시면 처리 속도가 빨라집니다."
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/sla-tracking.yml
+++ b/.github/workflows/sla-tracking.yml
@@ -1,0 +1,54 @@
+name: SLA Tracking (Draft)
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # daily 01:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: read
+
+jobs:
+  sla-tracking:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check first-response SLA candidates
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const now = Date.now();
+            const SLA_HOURS = 24;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            const candidates = issues
+              .filter(i => !i.pull_request)
+              .map(i => {
+                const created = new Date(i.created_at).getTime();
+                const ageHours = (now - created) / (1000 * 60 * 60);
+                return { number: i.number, title: i.title, ageHours };
+              })
+              .filter(i => i.ageHours > SLA_HOURS)
+              .sort((a, b) => b.ageHours - a.ageHours)
+              .slice(0, 20);
+
+            core.summary
+              .addHeading('SLA Tracking Report (Draft)')
+              .addRaw(`기준: 최초 응답 ${SLA_HOURS}시간 초과 후보\n\n`);
+
+            if (!candidates.length) {
+              core.summary.addRaw('초과 후보 없음\n');
+            } else {
+              for (const c of candidates) {
+                core.summary.addRaw(`- #${c.number} ${c.title} (${c.ageHours.toFixed(1)}h)\n`);
+              }
+            }
+
+            await core.summary.write();

--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -1,0 +1,63 @@
+name: Weekly Summary (Draft)
+
+on:
+  schedule:
+    - cron: "0 2 * * 1" # every Monday 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  weekly-summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build summary
+        id: summary
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'closed', per_page: 100
+            });
+            const merged = prs.filter(pr => pr.merged_at && pr.merged_at >= oneWeekAgo);
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'all', per_page: 100
+            });
+            const openedIssues = issues.filter(i => !i.pull_request && i.created_at >= oneWeekAgo).length;
+            const closedIssues = issues.filter(i => !i.pull_request && i.closed_at && i.closed_at >= oneWeekAgo).length;
+
+            const body = [
+              `## Weekly Summary (${new Date().toISOString().slice(0,10)})`,
+              '',
+              `- Merged PRs: ${merged.length}`,
+              `- Opened Issues: ${openedIssues}`,
+              `- Closed Issues: ${closedIssues}`,
+              '',
+              '### Notes',
+              '- This is a draft automation report.',
+              '- Add sprint goals and blockers manually if needed.'
+            ].join('\n');
+
+            core.setOutput('body', body);
+
+      - name: Create weekly issue
+        run: |
+          cat <<'EOF' > /tmp/weekly-summary.md
+          ${{ steps.summary.outputs.body }}
+          EOF
+
+      - name: Create weekly issue
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "weekly summary: automated draft"
+          content-filepath: /tmp/weekly-summary.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/adr/0001-async-triage-workflows-draft.md
+++ b/docs/adr/0001-async-triage-workflows-draft.md
@@ -1,0 +1,40 @@
+# ADR 0001: Adopt Draft Automation for Triage, SLA, and Weekly Summary
+
+- Date: 2026-04-27
+- Status: Proposed
+- Deciders: maintainers
+- Technical Story: repository operations improvement
+
+## Context
+
+이슈 증가에 따라 응답 지연, SLA 누락, 주간 진행상황 집계의 수작업 비용이 커지고 있습니다.
+
+## Decision
+
+다음 3개의 GitHub Actions 초안 워크플로우를 도입합니다.
+
+- 자동 응답 (`auto-response.yml`)
+- SLA 추적 (`sla-tracking.yml`)
+- 주간 요약 (`weekly-summary.yml`)
+
+## Options Considered
+
+1. 수동 운영 유지
+2. 외부 SaaS 도입
+3. GitHub Actions 기반 내부 자동화 (채택)
+
+## Consequences
+
+- Positive: 초기 운영 비용 절감, 응답 일관성 향상
+- Negative: 토큰 권한/실패 처리 설계 필요
+- Risks: 잘못된 자동 댓글, 과도한 알림
+
+## Follow-up Actions
+
+- [ ] 민감 이벤트에 대한 allowlist 적용
+- [ ] SLA 기준값 합의 및 환경변수화
+- [ ] 주간 요약 포맷 확정
+
+## References
+
+- Workflow files: `.github/workflows/*.yml`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# ADR (Architecture Decision Record)
+
+SentiVision의 아키텍처 및 운영 의사결정을 기록합니다.
+
+## Structure
+
+- `template.md`: ADR 작성 템플릿
+- `NNNN-short-title.md`: 채번된 ADR 문서
+
+## Naming
+
+- 번호 4자리 고정: `0001`, `0002`, ...
+- 소문자 kebab-case 제목
+
+예시:
+
+- `0001-choose-knn-baseline-model.md`
+- `0002-use-fastapi-for-serving.md`
+
+## Status Lifecycle
+
+- Proposed
+- Accepted
+- Superseded
+- Rejected

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,37 @@
+# ADR NNNN: <Decision Title>
+
+- Date: YYYY-MM-DD
+- Status: Proposed | Accepted | Superseded | Rejected
+- Deciders: <names>
+- Technical Story: <issue/pr/discussion link>
+
+## Context
+
+문제 배경, 제약, 목표를 기술합니다.
+
+## Decision
+
+채택한 결정을 간결하게 서술합니다.
+
+## Options Considered
+
+1. Option A
+2. Option B
+3. Option C
+
+## Consequences
+
+- Positive:
+- Negative:
+- Risks:
+
+## Follow-up Actions
+
+- [ ] 작업 1
+- [ ] 작업 2
+
+## References
+
+- PR:
+- Discussion:
+- Metrics:

--- a/docs/wiki/Development-Guide.md
+++ b/docs/wiki/Development-Guide.md
@@ -1,0 +1,51 @@
+# Development Guide
+
+SentiVision 협업 개발 기준입니다.
+
+## Branch Strategy
+
+- 기본: `main` 보호 브랜치
+- 작업: `feat/<issue>-<slug>`, `fix/<issue>-<slug>`, `docs/<issue>-<slug>`
+- 모든 변경은 PR 기반으로 병합
+
+예시:
+
+- `feat/11-color-emotion-preprocessing`
+- `feat/12-rest-api-endpoint`
+- `feat/10-model-pipeline`
+
+## Commit Convention
+
+Conventional Commits를 사용합니다.
+
+```text
+<type>(<scope>): <subject>
+```
+
+예시:
+
+- `feat(api): add /analyze REST endpoint`
+- `feat(model): extract KNN emotion classifier`
+- `docs(wiki): add troubleshooting guide`
+
+## Pull Request Rules
+
+- PR 템플릿 준수
+- `Closes #<issue>` 명시
+- 리뷰 코멘트 태그 사용
+  - `[MUST]` 머지 전 필수
+  - `[SHOULD]` 강력 권고
+  - `[CONSIDER]` 선택
+
+## ADR Process
+
+아키텍처/운영 의사결정은 ADR로 기록합니다.
+
+- 위치: `docs/adr/`
+- 템플릿: `docs/adr/template.md`
+- 파일명 규칙: `NNNN-short-title.md`
+
+## Next Docs
+
+- 초기 온보딩: [Getting Started](Getting-Started.md)
+- 장애 대응: [Troubleshooting](Troubleshooting.md)

--- a/docs/wiki/Discussions-Category-Design.md
+++ b/docs/wiki/Discussions-Category-Design.md
@@ -1,0 +1,31 @@
+# Discussions Category Design
+
+GitHub Discussions 운영 카테고리 설계안입니다.
+
+## Target Categories
+
+- Announcements: 릴리즈/운영 공지
+- General: 일반 커뮤니티 대화
+- Ideas: 기능 제안 및 RFC 접수
+- Q&A: 사용/설치/오류 문의
+- Polls: 의사결정 투표
+- Show and tell: 결과 공유
+
+## Logical Extensions (운영 규약)
+
+GitHub API 제약으로 커스텀 카테고리 자동 생성은 어려우므로, 아래를 라벨/접두어로 운영합니다.
+
+- RFC: `Ideas` 카테고리 + 제목 접두어 `[RFC]`
+- Support: `Q&A` 카테고리 사용
+- Operations: `Announcements` 또는 `General` + 태그 `[OPS]`
+
+## Moderation Rules
+
+- RFC는 배경, 제안, 대안, 영향 분석 필수
+- Q&A는 재현 절차/환경 정보 필수
+- 운영 공지는 SLA/상태 변화 수치 포함 권장
+
+## Related Docs
+
+- [Development Guide](Development-Guide.md)
+- [Troubleshooting](Troubleshooting.md)

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,48 @@
+# Getting Started
+
+SentiVision 개발을 시작하는 최소 절차입니다.
+
+## Prerequisites
+
+- macOS 또는 Linux
+- Python 3.12+
+- Git
+- GitHub CLI (`gh`)
+
+## Setup
+
+1. 저장소 클론
+
+```bash
+git clone https://github.com/acertainromance401/SentiVision.git
+cd SentiVision
+```
+
+2. 가상환경 준비
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -r requirements.txt  # 파일이 없으면 필요한 패키지 개별 설치
+```
+
+3. 기본 데이터/모듈 검증
+
+```bash
+python3 -m src.model.emotion_classifier train
+python3 -m src.model.emotion_classifier predict 255 87 51
+```
+
+## First Run
+
+- 전처리 파이프라인 실행:
+
+```bash
+python3 -c "from src.data.preprocessing import run_pipeline; print(run_pipeline('base_model/color_emotion_labeled_updated.csv').summary())"
+```
+
+## Next Docs
+
+- 개발 규칙/브랜치 전략: [Development Guide](Development-Guide.md)
+- 자주 막히는 이슈 해결: [Troubleshooting](Troubleshooting.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,7 @@
+# SentiVision Wiki Home
+
+- [Getting Started](Getting-Started.md)
+- [Development Guide](Development-Guide.md)
+- [Troubleshooting](Troubleshooting.md)
+
+문서 간 상호 링크가 포함되어 있어 어느 문서에서 시작해도 탐색이 가능합니다.

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -1,0 +1,57 @@
+# Troubleshooting
+
+자주 발생하는 문제와 해결 방법입니다.
+
+## 1) `gh` 인증/권한 오류
+
+증상:
+
+- `gh api` 호출 시 `401` 또는 권한 부족
+
+해결:
+
+```bash
+gh auth status
+gh auth refresh -s repo -s project -s read:org
+```
+
+## 2) Python 의존성 충돌 (SciPy/Numpy)
+
+증상:
+
+- `A NumPy version >=... is required for this version of SciPy`
+
+해결:
+
+```bash
+source .venv/bin/activate
+pip install "numpy<2.3" "scipy>=1.11" -U
+pip install -U scikit-learn pandas matplotlib
+```
+
+## 3) PR 생성 시 본문 깨짐
+
+증상:
+
+- 한글 본문이 터미널 인코딩 영향으로 깨짐
+
+해결:
+
+```bash
+gh pr create --title "..." --body-file /tmp/pr_body.md
+```
+
+## 4) Branch protection API 422
+
+증상:
+
+- `gh api`의 `-f key=null` 전송 시 스키마 에러
+
+해결:
+
+- JSON 파일을 만들어 `curl -d @file.json`로 전송
+
+## Next Docs
+
+- 설치/첫 실행: [Getting Started](Getting-Started.md)
+- 개발 표준: [Development Guide](Development-Guide.md)


### PR DESCRIPTION
## Description

프로젝트 운영 문서화/협업 체계를 위해 다음을 추가합니다.

- Wiki 문서 3종 + 상호 링크
- ADR 템플릿 및 `docs/adr/` 구조
- 자동 응답, SLA 추적, 주간 요약 GitHub Actions 초안
- Discussions 카테고리 운영 설계 문서

## Scope

- `docs/wiki/Getting-Started.md`
- `docs/wiki/Development-Guide.md`
- `docs/wiki/Troubleshooting.md`
- `docs/wiki/Home.md`
- `docs/wiki/Discussions-Category-Design.md`
- `docs/adr/template.md`
- `docs/adr/README.md`
- `docs/adr/0001-async-triage-workflows-draft.md`
- `.github/workflows/auto-response.yml`
- `.github/workflows/sla-tracking.yml`
- `.github/workflows/weekly-summary.yml`

## Related Ops

- Discussions enabled: `has_discussions=true`
- RFC discussion opened: #25

## Notes

GitHub API 제약으로 Discussions 카테고리의 커스텀 생성은 불가하여,
기본 카테고리(`Ideas`, `Q&A` 등)에 운영 규약(접두어/템플릿)을 적용하는 방식으로 설계했습니다.
